### PR TITLE
Reversed Input Params and Quoted Passwords

### DIFF
--- a/Misc/MachineSetup/Azure_VM_CustomScript_Windows.ps1
+++ b/Misc/MachineSetup/Azure_VM_CustomScript_Windows.ps1
@@ -34,7 +34,7 @@ $web_client.DownloadFile($url, $ps1Path)
 $SecureAccountPassword = ConvertTo-SecureString $AccountPassword -AsPlainText -Force
 $credential = New-Object System.Management.Automation.PSCredential("${env:COMPUTERNAME}\${AccountName}", $SecureAccountPassword)
 Enable-PSRemoting -Force
-Invoke-Command -FilePath $ps1Path -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList $AccountPassword, $IPythonPassword
+Invoke-Command -FilePath $ps1Path -Credential $credential -ComputerName $env:COMPUTERNAME -ArgumentList "${AccountPassword}", "${IPythonPassword}"
 Disable-PSRemoting -Force
 echo "Ending CustomScript process"
 

--- a/Misc/MachineSetup/Azure_VM_Setup_Windows.ps1
+++ b/Misc/MachineSetup/Azure_VM_Setup_Windows.ps1
@@ -13,7 +13,7 @@
 #    permissions and limitations under the License.
 #
 ################################################################################
-param([string]$IPythonPassword, [string]$AccountPassword)
+param([string]$AccountPassword, [string]$IPythonPassword)
 $previous_pwd = $pwd
 
 $sysDrive = (Get-ChildItem env:SYSTEMDRIVE).Value
@@ -177,7 +177,7 @@ function ScheduleAndStartIPython(){
         $Credentials = New-Object System.Management.Automation.PSCredential -ArgumentList $username, $SecureAccountPassword 
         $AccountPassword = $Credentials.GetNetworkCredential().Password 
     } 
-    Register-ScheduledTask $taskName -Action $action -Trigger $trigger -Settings $settings -User $username -Password $AccountPassword    
+    Register-ScheduledTask $taskName -Action $action -Trigger $trigger -Settings $settings -User "${username}" -Password "${AccountPassword}"
     $AccountPassword = $null
 
     # If the user wants to stop the auto restart of IPython run 'Unregister-ScheduledTask Start_IPython_Notebook'


### PR DESCRIPTION
We had a mismatch in the order we expect params for the custom and
windows setup script.  I also took a moment to quote some arguments just
to be safe.
