### PR TITLE
Update TrainTipPredictionModelRxPy.sql

### DIFF
--- a/Misc/PythonSQL/TrainTipPredictionModelRxPy.sql
+++ b/Misc/PythonSQL/TrainTipPredictionModelRxPy.sql
@@ -20,11 +20,10 @@ BEGIN
     @script = N'
 import numpy
 import pickle
-import pandas
-from revoscalepy.functions.RxLogit import rx_logit_ex
-from revoscalepy.functions.RxPredict import rx_predict_ex
+from revoscalepy.functions.RxLogit import rx_logit
+from revoscalepy.functions.RxPredict import rx_predict
 
-logitObj = rx_logit_ex("tipped ~ passenger_count + trip_distance + trip_time_in_secs + direct_distance", data=InputDataSet);
+logitObj = rx_logit("tipped ~ passenger_count + trip_distance + trip_time_in_secs + direct_distance", data=InputDataSet);
 
 ## Serialize model
 trained_model = pickle.dumps(logitObj)


### PR DESCRIPTION
Fixed to API specification change of RevoScalePy due to version upgrade from SQL Server 2017 CTP to SQL Server 2017 RC
This file is used by In-database Python Analytics tutorial(https://docs.microsoft.com/en-us/sql/advanced-analytics/tutorials/sqldev-in-database-python-for-sql-developers).