### PR TITLE
Update PredictTipSingleModeSciKitPy.sql

### DIFF
--- a/Misc/PythonSQL/PredictTipSingleModeSciKitPy.sql
+++ b/Misc/PythonSQL/PredictTipSingleModeSciKitPy.sql
@@ -33,7 +33,6 @@ BEGIN
 		@script = N'
 import pickle
 import numpy
-import pandas
 
 # Load model and unserialize
 mod = pickle.loads(model)


### PR DESCRIPTION
Fixed to API specification change of RevoScalePy due to version upgrade from SQL Server 2017 CTP to SQL Server 2017 RC
This file is used by In-database Python Analytics tutorial(https://docs.microsoft.com/en-us/sql/advanced-analytics/tutorials/sqldev-in-database-python-for-sql-developers).